### PR TITLE
Fix wxss parsing error

### DIFF
--- a/lib/wxss.js
+++ b/lib/wxss.js
@@ -17,7 +17,7 @@ module.exports = function (file, content) {
       if (files.indexOf(file) == -1) files.push(file)
       generator.addMapping({
         source: file,
-        original: {line: lineNum, column: colNum},
+        original: {line: Number(lineNum), column: Number(colNum)},
         generated: {line: lnum, column: 0}
       })
       return ''


### PR DESCRIPTION
Some may encounter such error when parsing wxss:

```
Error: original.line and original.column are not numbers -- you probably meant to omit the original mapping entirely and only map the generated position. If so, pass null for the original mapping instead of an object with empty or null values.
    at SourceMapGenerator_validateMapping [as _validateMapping] (/home/perqin/.local/lib/node_modules/wept/node_modules/source-map/lib/source-map-generator.js:267:15)
    at SourceMapGenerator_addMapping [as addMapping] (/home/perqin/.local/lib/node_modules/wept/node_modules/source-map/lib/source-map-generator.js:101:12)
    at /home/perqin/.local/lib/node_modules/wept/build/wxss.js:26:17
    at String.replace (<anonymous>)
    at /home/perqin/.local/lib/node_modules/wept/build/wxss.js:23:17
    at Array.forEach (<anonymous>)
    at module.exports (/home/perqin/.local/lib/node_modules/wept/build/wxss.js:20:23)
    at /home/perqin/.local/lib/node_modules/wept/build/parser.js:82:11
    at ChildProcess.exithandler (child_process.js:262:7)
    at emitTwo (events.js:125:13)
```

This is because `source-map` library will check the type of passed `line` and `column` parameters.